### PR TITLE
adding precision argument to threshold_from_p

### DIFF
--- a/core/moods_scan.cpp
+++ b/core/moods_scan.cpp
@@ -89,7 +89,7 @@ namespace MOODS { namespace scan{
         // max score is what we want
         for (size_t i = 0; i < matrices.size(); ++i){
             if (!ok[i]){
-                current[i] = tools::threshold_from_p(matrices[i],bg,p,4);
+                current[i] = tools::threshold_from_p(matrices[i],bg,p,4,2000.0);
                 lower[i] = tools::min_score(matrices[i],4) - 1.0;
             }
         }

--- a/core/moods_tools.cpp
+++ b/core/moods_tools.cpp
@@ -19,8 +19,6 @@ using std::size_t;
 
 namespace MOODS { namespace tools{
     
-const double PVAL_DP_MULTIPLIER = 2000.0;
-
 // Generates a flat background distribution
 vector<double> flat_bg(const unsigned int alphabet_size)
 {
@@ -139,7 +137,7 @@ score_matrix log_odds(const score_matrix &mat, const vector<double> &bg, const d
 }
 
 // // Calculates a threshold for a scoring matrix from a given p value
-double threshold_from_p(const score_matrix &pssm, const vector<double> &bg, const double &p)
+double threshold_from_p(const score_matrix &pssm, const vector<double> &bg, const double &p, const double &precision)
 {
     
     // Approximate the scoring matrix with integer matrix for DP
@@ -157,10 +155,10 @@ double threshold_from_p(const score_matrix &pssm, const vector<double> &bg, cons
         for (size_t j = 0; j < a; ++j)
         {
             if (pssm[j][i] > 0.0){
-                mat[j][i] = (long) ( PVAL_DP_MULTIPLIER * pssm[j][i] + 0.5 );
+                mat[j][i] = (long) ( precision * pssm[j][i] + 0.5 );
             }
             else {
-                mat[j][i] = (long) ( PVAL_DP_MULTIPLIER * pssm[j][i] - 0.5 );
+                mat[j][i] = (long) ( precision * pssm[j][i] - 0.5 );
             }
         }
     }
@@ -218,7 +216,7 @@ double threshold_from_p(const score_matrix &pssm, const vector<double> &bg, cons
         sum += table0[r];
         if (sum > p)
         {
-            return (double) ((r + n * minV + 1) / PVAL_DP_MULTIPLIER);
+            return (double) ((r + n * minV + 1) / precision);
         }
     }
 
@@ -433,7 +431,7 @@ double min_score(const score_matrix &mat, const size_t a){
 }
 
 // temporary threshold-from-p for high-order pwms
-double threshold_from_p(const score_matrix &pssm, const vector<double> &bg, const double &p, const size_t a)
+double threshold_from_p(const score_matrix &pssm, const vector<double> &bg, const double &p, const size_t a, const double &precision)
 {
     
     long rows = pssm.size();
@@ -456,10 +454,10 @@ double threshold_from_p(const score_matrix &pssm, const vector<double> &bg, cons
         for (size_t CODE = 0; CODE < rows; ++CODE)
         {
             if (pssm[CODE][i] > 0.0){
-                mat[CODE][i] = (long) ( PVAL_DP_MULTIPLIER * pssm[CODE][i] + 0.5 );
+                mat[CODE][i] = (long) ( precision * pssm[CODE][i] + 0.5 );
             }
             else {
-                mat[CODE][i] = (long) ( PVAL_DP_MULTIPLIER * pssm[CODE][i] - 0.5 );
+                mat[CODE][i] = (long) ( precision * pssm[CODE][i] - 0.5 );
             }
         }
     }
@@ -532,7 +530,7 @@ double threshold_from_p(const score_matrix &pssm, const vector<double> &bg, cons
         sum += table2[r];
         if (sum > p)
         {
-            return (double) ((r + cols * minV + 1) / PVAL_DP_MULTIPLIER);
+            return (double) ((r + cols * minV + 1) / precision);
         }
     }
 

--- a/core/moods_tools.h
+++ b/core/moods_tools.h
@@ -17,7 +17,7 @@ namespace MOODS { namespace tools{
     score_matrix log_odds(const score_matrix &mat, const std::vector<double> &bg, const double ps, const double log_base);
     
     // threshold from p
-    double threshold_from_p(const score_matrix &mat, const std::vector<double> &bg, const double &p);
+    double threshold_from_p(const score_matrix &mat, const std::vector<double> &bg, const double &p, const double &precision);
     
     // min / max
     double max_score(const score_matrix &mat);
@@ -27,7 +27,7 @@ namespace MOODS { namespace tools{
     // high-order versions
     double max_score(const score_matrix &mat, const size_t a);
     double min_score(const score_matrix &mat, const size_t a);
-    double threshold_from_p(const score_matrix &mat, const std::vector<double> &bg, const double &p, size_t a);
+    double threshold_from_p(const score_matrix &mat, const std::vector<double> &bg, const double &p, size_t a, const double &precision);
     score_matrix reverse_complement(const std::vector<std::vector<double>> &mat, size_t a);
     score_matrix log_odds(const score_matrix &mat, const std::vector<std::vector<double> >& low_order_terms,
                           const std::vector<double> &bg, const double ps, const size_t a);

--- a/python/scripts/ex-basic-usage.py
+++ b/python/scripts/ex-basic-usage.py
@@ -63,7 +63,7 @@ matrices = [MOODS.parsers.pfm_to_log_odds(matrix_directory + filename, bg, pseud
 # reverse complements
 matrices = matrices + [MOODS.tools.reverse_complement(m) for m in matrices]
 
-thresholds = [MOODS.tools.threshold_from_p(m, bg, pvalue) for m in matrices]
+thresholds = [MOODS.tools.threshold_from_p(m, bg, pvalue, 2000.0) for m in matrices]
 
 
 end = time.clock()

--- a/python/scripts/ex-mixing-data.py
+++ b/python/scripts/ex-mixing-data.py
@@ -42,7 +42,7 @@ matrix_names = pfms + adms
 
 # threshold selection
 p = 0.0001
-thresholds = [MOODS.tools.threshold_from_p(m,bg,p) for m in lo_pfms] + [MOODS.tools.threshold_from_p(m,bg,p,4) for m in lo_adms]
+thresholds = [MOODS.tools.threshold_from_p(m,bg,p,2000.0) for m in lo_pfms] + [MOODS.tools.threshold_from_p(m,bg,p,4,2000.0) for m in lo_adms]
 
 # scanning
 results = MOODS.scan.scan_dna(seq, matrices, bg, thresholds, 7)

--- a/python/scripts/ex-scanner.py
+++ b/python/scripts/ex-scanner.py
@@ -21,7 +21,7 @@ matrix_names = [filename for filename in os.listdir(matrix_directory) if filenam
 bg = MOODS.tools.flat_bg(4)
 matrices = [MOODS.parsers.pfm_to_log_odds(matrix_directory + filename, bg, 1) for filename in matrix_names]
 # thresholds computed from p-value
-thresholds = [MOODS.tools.threshold_from_p(m, bg, 0.001) for m in matrices]
+thresholds = [MOODS.tools.threshold_from_p(m, bg, 0.001, 2000.0) for m in matrices]
 
 
 # instead of just calling the scan function, we'll build a scanner object

--- a/python/scripts/moods_dna.py
+++ b/python/scripts/moods_dna.py
@@ -246,7 +246,7 @@ if args.p_val is not None or args.t is not None:
         bg = args.bg
         if args.verbosity >= 1:
             print("{}: computing thresholds from p-value".format(os.path.basename(__file__)), file=sys.stderr)
-        thresholds = [MOODS.tools.threshold_from_p(m,bg,args.p_val,4) for m in matrices_all]        
+        thresholds = [MOODS.tools.threshold_from_p(m,bg,args.p_val,4,2000.0) for m in matrices_all]        
         if args.verbosity >= 3:
             for (m, t) in zip(matrix_names, thresholds):
                 print("{}: threshold for {} is {}".format(os.path.basename(__file__), m, t), file=sys.stderr)
@@ -273,7 +273,7 @@ if args.p_val is not None or args.t is not None:
                     print("{}: estimated background for {} is {}".format(os.path.basename(__file__), header, bg), file=sys.stderr)
                 if args.verbosity >= 1:
                     print("{}: computing thresholds from p-value for sequence {}".format(os.path.basename(__file__), header), file=sys.stderr)
-                thresholds = [MOODS.tools.threshold_from_p(m,bg,args.p_val,4) for m in matrices_all]
+                thresholds = [MOODS.tools.threshold_from_p(m,bg,args.p_val,4,2000.0) for m in matrices_all]
                 if args.verbosity >= 3:
                     for (m, t) in zip(matrix_names, thresholds):
                         print("{}: threshold for {} is {}".format(os.path.basename(__file__), m, t), file=sys.stderr)


### PR DESCRIPTION
We are finishing migration from Biopython to MOODS, and the only remaining bit was the possibility to specify arbitrary precision when calculating FPR thresholds with ```thresholds_from_p```. This pull request implements that.

Since the function is already overloaded, I could not cleanly keep the existing ```PVAL_DP_MULTIPLIER``` as a default (unless using C++'s default arguments which I, however, am not familiar with). So I've had to add ```2000.0``` to all code calling ```thresholds_from_p```.

I believe that is better to leave the choice to the user as to which precision to set, rather than hardcoding. Computing capabilities vary a lot (for us, ```10000``` is a good compromise - for others, ```2000``` is already too much). But I bow to your judgment :)

There are probably better ways of doing this, but I bet they involve some refactoring.