### PR TITLE
Support old architectures when compiling

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -7,7 +7,7 @@ setup.py file for MOODS
 from distutils.core import setup, Extension
 
 common_includes = ["core/"]
-common_compile_args = ['-march=native', '-O3', '-fPIC', '--std=c++11']
+common_compile_args = ['-mtune=generic', '-O3', '-fPIC', '--std=c++11']
 
 
 tools_mod = Extension('MOODS._tools',


### PR DESCRIPTION
The "-march=native" option produces compiled code that is optimized for the chip architecture of the build machine.  This can produce compiled code that will not run on older chips, instead crashing with "illegal instruction".

In particular, the bioconda compiled package available here (https://github.com/bioconda/bioconda-recipes/tree/master/recipes/moods) apparently is compiled on a Haswell (AVX2) machine, preventing a wide number of users running on older machines from successfully installing MOODS using conda.