### PR TITLE
Needed setuptools

### DIFF
--- a/python/readme.MD
+++ b/python/readme.MD
@@ -17,7 +17,7 @@ The quickest way to install MOODS is using pip:
 
 (b) Install the module for all users:
 
-    pip install MOODS-python
+    sudo pip install MOODS-python
 
 Installing the MOODS package from PyPi installs the `moods-dna.py` script to
 your Python executable directory. Test it by running:

--- a/python/readme.MD
+++ b/python/readme.MD
@@ -44,7 +44,7 @@ don't have your pip configured or you just want a quick throwaway install.
 
     python setup.py build_ext --inplace
     cd scripts
-    ln -s ../MOODS/    
+    ln -s ../MOODS/
 
 (b) Install the module to your local Python library path:
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,7 @@
 setup.py file for MOODS
 """
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from os import path
 
 common_includes = ["core/"]
@@ -53,7 +53,7 @@ setup (name = 'MOODS-python',
        version = '1.9.4',
        description = 'MOODS: Motif Occurrence Detection Suite',
        long_description = long_description,
-       long_description_content_type="text/markdown",
+       long_description_content_type='text/markdown',
        maintainer = "Janne H. Korhonen",
        maintainer_email = "janne.h.korhonen@gmail.com",
        url='https://www.cs.helsinki.fi/group/pssmfind/',


### PR DESCRIPTION
A couple of minor changes.

Most importantly, I've switched to setuptools to make the markdown readme work.

Without it, we would either have to rewrite the readme in RST format, or keep the long description of the package empty. Moving to setuptools seemed the best option (no API change, as you can see).