### PR TITLE
Fix a bunch of compilation warnings from clang++.

### DIFF
--- a/core/match_types.cpp
+++ b/core/match_types.cpp
@@ -1,12 +1,13 @@
 
 #include <vector>
 #include <string>
+#include <utility>
 
 #include "match_types.h"
 
 namespace MOODS {
     
     variant::variant(){}
-    variant::variant(size_t s, size_t e, std::string seq): start_pos(s), end_pos(e), modified_seq(seq) {}
+    variant::variant(size_t s, size_t e, std::string seq): start_pos(s), end_pos(e), modified_seq(std::move(seq)) {}
     
 }

--- a/core/moods_scan.cpp
+++ b/core/moods_scan.cpp
@@ -94,8 +94,6 @@ namespace MOODS { namespace scan{
             }
         }
 
-        bool done = 0;
-
         int iteration = 0;
 
 
@@ -249,7 +247,7 @@ namespace MOODS { namespace scan{
                 }
 
                 for (size_t j = 0; j < cols; ++j){
-                    CODE = MASK & (CODE << SHIFT) | alphabet_map[seq[i+j+q-1]];
+                    CODE = (MASK & (CODE << SHIFT)) | alphabet_map[seq[i+j+q-1]];
                     score += matrix[CODE][j];
                 }
 

--- a/core/moods_tools.cpp
+++ b/core/moods_tools.cpp
@@ -141,35 +141,35 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
 {
     
     // Approximate the scoring matrix with integer matrix for DP
-    long a = pssm.size();
-    long n = pssm[0].size();
+    size_t a = pssm.size();
+    size_t n = pssm[0].size();
 
 
-    vector<vector<long> > mat(a, vector<long>(n));
+    vector<vector<size_t> > mat(a, vector<size_t>(n));
 
-    long maxT = 0;
-    long minV = std::numeric_limits<long>::max();
+    size_t maxT = 0;
+    size_t minV = std::numeric_limits<size_t>::max();
 
     for (size_t i = 0; i < n; ++i)
     {
         for (size_t j = 0; j < a; ++j)
         {
             if (pssm[j][i] > 0.0){
-                mat[j][i] = (long) ( precision * pssm[j][i] + 0.5 );
+                mat[j][i] = (size_t) ( precision * pssm[j][i] + 0.5 );
             }
             else {
-                mat[j][i] = (long) ( precision * pssm[j][i] - 0.5 );
+                mat[j][i] = (size_t) ( precision * pssm[j][i] - 0.5 );
             }
         }
     }
 
     for (size_t i = 0; i < n; ++i)
     {
-        long max = mat[0][i];
-        long min = max;
+        size_t max = mat[0][i];
+        size_t min = max;
         for (size_t j = 1; j < a; ++j)
         {
-            long v = mat[j][i];
+            size_t v = mat[j][i];
             if (max < v)
                 max = v;
             else if (min > v)
@@ -180,7 +180,7 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
             minV = min;
     }
 
-    long R = maxT - n * minV;
+    size_t R = maxT - n * minV;
 
     vector<double> table0(R + 1, 0.0);
     vector<double> table1(R + 1, 0.0);
@@ -193,10 +193,10 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
         for (size_t j = 0; j < a; ++j)
         {
             long s = mat[j][i] - minV;
-            for (long r = s; r <= R; ++r)
+            for (size_t r = s; r <= R; ++r)
                 table1[r] += bg[j] * table0[r - s];
         }
-        for (long r = 0; r <= R; ++r)
+        for (size_t r = 0; r <= R; ++r)
         {
             table0[r] = table1[r];
             table1[r] = 0.0;
@@ -211,7 +211,7 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
         return max_score(pssm) - min_delta(pssm)/2;
     }
         
-    for (long r = R-1; r >= 0; --r)
+    for (size_t r = R-1; r != ((size_t)-1); --r)
     {
         sum += table0[r];
         if (sum > p)
@@ -439,8 +439,8 @@ double min_score(const score_matrix &mat, const size_t a){
 double threshold_from_p_with_precision(const score_matrix &pssm, const vector<double> &bg, const double &p, const double precision, const size_t a)
 {
     
-    long rows = pssm.size();
-    long cols = pssm[0].size();
+    size_t rows = pssm.size();
+    size_t cols = pssm[0].size();
 
     unsigned int q = MOODS::misc::q_gram_size(rows, a);
 
@@ -449,20 +449,20 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
     const bits_t Q_CODE_SIZE  =  (1 << (SHIFT * (q-1)));
     const bits_t Q_MASK = Q_CODE_SIZE - 1;
 
-    vector<vector<long> > mat(rows, vector<long>(cols));
+    vector<vector<size_t> > mat(rows, vector<size_t>(cols));
 
-    long maxT = 0;
-    long minV = std::numeric_limits<long>::max();
+    size_t maxT = 0;
+    size_t minV = std::numeric_limits<size_t>::max();
 
     for (size_t i = 0; i < cols; ++i)
     {
         for (size_t CODE = 0; CODE < rows; ++CODE)
         {
             if (pssm[CODE][i] > 0.0){
-                mat[CODE][i] = (long) ( precision * pssm[CODE][i] + 0.5 );
+                mat[CODE][i] = (size_t) ( precision * pssm[CODE][i] + 0.5 );
             }
             else {
-                mat[CODE][i] = (long) ( precision * pssm[CODE][i] - 0.5 );
+                mat[CODE][i] = (size_t) ( precision * pssm[CODE][i] - 0.5 );
             }
         }
     }
@@ -470,11 +470,11 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
 
     for (size_t i = 0; i < cols; ++i)
     {
-        long max = mat[0][i];
-        long min = max;
+        size_t max = mat[0][i];
+        size_t min = max;
         for (size_t CODE = 1; CODE < rows; ++CODE)
         {
-            long v = mat[CODE][i];
+            size_t v = mat[CODE][i];
             if (max < v)
                 max = v;
             else if (min > v)
@@ -485,7 +485,7 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
             minV = min;
     }
 
-    long R = maxT - cols * minV;
+    size_t R = maxT - cols * minV;
 
     vector<vector<double>> table0(Q_CODE_SIZE, vector<double>(R + 1, 0));
 
@@ -508,8 +508,8 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
             bits_t CODE_PREFIX = (CODE >> SHIFT) & Q_MASK;
             bits_t CODE_SUFFIX = CODE & Q_MASK;
             bits_t CHAR = CODE & A_MASK;
-            long s = mat[CODE][i] - minV;
-            for (long r = s; r <= R; ++r)
+            size_t s = mat[CODE][i] - minV;
+            for (size_t r = s; r <= R; ++r)
                 table1[CODE_SUFFIX][r] += bg[CHAR] * table0[CODE_PREFIX][r - s];
         }
         table0 = table1;
@@ -517,7 +517,7 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
 
 
     vector<double> table2(R+1, 0.0);
-    for (long r = 0; r < R+1; ++r){
+    for (size_t r = 0; r < R+1; ++r){
         for (bits_t CODE = 0; CODE < Q_CODE_SIZE; ++CODE){
             table2[r] += table0[CODE][r];
         }
@@ -530,7 +530,7 @@ double threshold_from_p_with_precision(const score_matrix &pssm, const vector<do
         return max_score(pssm, a) - min_delta(pssm)/2;;
     }
 
-    for (long r = R-1; r >= 0; --r)
+    for (size_t r = R-1; r >= 0; --r)
     {
         sum += table2[r];
         if (sum > p)
@@ -585,7 +585,7 @@ vector<MOODS::variant> snp_variants(const std::string &seq){
     
     for (size_t i = 0; i < seq.size(); ++i){
         for (size_t j = 0; j < snp_alt[seq[i]].size(); ++j){
-            ret.push_back(variant{i,i+1,snp_alt[seq[i]].substr(j,1)});
+            ret.emplace_back(i,i+1,snp_alt[seq[i]].substr(j,1));
         }
     }
     

--- a/core/motif.h
+++ b/core/motif.h
@@ -23,6 +23,8 @@ public:
     virtual unsigned int alphabet_size() = 0;
     virtual unsigned int window_pos() = 0;
     virtual double threshold() = 0;
+
+    virtual ~Motif() = default;
 };
 
 

--- a/core/motif_0.cpp
+++ b/core/motif_0.cpp
@@ -25,17 +25,17 @@ vector<double> expected_differences(const score_matrix &mat, const vector<double
     size_t m = mat[0].size();
     vector<double> ret(m);
 
-    for (int i = 0; i < m; ++i)
+    for (size_t i = 0; i < m; ++i)
     {
         double max = -std::numeric_limits<double>::infinity();
-        for (int j = 0; j < a; ++j)
+        for (size_t j = 0; j < a; ++j)
         {
             max = std::max(max, mat[j][i]);
         }
 
         ret[i] = max;
 
-        for (int j = 0; j < a; ++j)
+        for (size_t j = 0; j < a; ++j)
         {
             ret[i] -= bg[j] * mat[j][i];
         }
@@ -59,9 +59,9 @@ unsigned int window_position(const vector<double> &ed, unsigned int l, unsigned 
         }
 
         double max = current;
-        int window_pos = 0;
+        unsigned int window_pos = 0;
 
-        for (int i = 0; i < m - l; ++i)
+        for (unsigned int i = 0; i < m - l; ++i)
         {
             current -= ed[i];
             current += ed[i+l];
@@ -93,11 +93,11 @@ vector<unsigned int> compute_lookahead_order(const vector<double> &ed, unsigned 
     else
     {
         vector<unsigned int> order(m-l, 0);
-        for (int i = 0; i < window_pos; ++i)
+        for (unsigned int i = 0; i < window_pos; ++i)
         {
             order[i] = i;
         }
-        for (int i = window_pos+l; i < m; ++i)
+        for (unsigned int i = window_pos+l; i < m; ++i)
         {
             order[i-l] = i;
         }
@@ -122,7 +122,7 @@ vector<double> compute_lookahead_scores(const score_matrix &mat, const vector<un
         std::vector<double> scores(m-l,0);
         
         double total = 0;
-        for (int i = m-l-1; i >= 0; --i)
+        for (unsigned int i = m-l-1; i != ((unsigned int)-1); --i)
         {
             double max = -std::numeric_limits<double>::infinity();
             for (unsigned int j = 0; j < a; ++j)

--- a/core/motif_h.cpp
+++ b/core/motif_h.cpp
@@ -23,8 +23,8 @@ vector<double> MotifH::expected_scores(const vector<double> &bg){
     const bits_t A_MASK = (1 << (SHIFT)) - 1;
 
     vector<double> ret(cols, 0);
-    for (int i = 0; i < cols; ++i){
-        for (int j = 0; j < rows; ++j){
+    for (unsigned int i = 0; i < cols; ++i){
+        for (unsigned int j = 0; j < rows; ++j){
             double bg_prop = 1;
             for (unsigned int k = 0; k < q; ++k){
                 bg_prop *= bg[A_MASK & (j >> (SHIFT * (q - 1 - k)))];
@@ -39,7 +39,10 @@ vector<double> MotifH::expected_scores(const vector<double> &bg){
 
 vector<vector<double>> MotifH::max_scores_f(size_t start, size_t end){
 
-    double wsize = end - start;
+    size_t wsize = end - start;
+    if (end <= start) {
+        wsize = 0;
+    }
     vector<vector<double>> max_scores (wsize, vector<double> (Q_CODE_SIZE, 0));
 
     if (end > start){
@@ -47,7 +50,7 @@ vector<vector<double>> MotifH::max_scores_f(size_t start, size_t end){
             max_scores[0][j & Q_MASK] = std::max(mat[j][start], max_scores[0][j & Q_MASK]);
         }
 
-        for (unsigned int i = 1 ; i < wsize; ++i){
+        for (size_t i = 1 ; i < wsize; ++i){
             for (unsigned int j = 0; j < rows; ++j){
                 max_scores[i][j & Q_MASK] = std::max(mat[j][i+start] + max_scores[i-1][j >> SHIFT], max_scores[i][j & Q_MASK]);
             }
@@ -59,7 +62,10 @@ vector<vector<double>> MotifH::max_scores_f(size_t start, size_t end){
 
 vector<vector<double>> MotifH::max_scores_b(size_t start, size_t end){
 
-    double wsize = end - start;
+    size_t wsize = end - start;
+    if (end <= start) {
+        wsize = 0;
+    }
     vector<vector<double>> max_scores (wsize, vector<double> (Q_CODE_SIZE, 0));
 
 
@@ -70,7 +76,7 @@ vector<vector<double>> MotifH::max_scores_b(size_t start, size_t end){
             max_scores[wsize-1][j >> SHIFT] = std::max(mat[j][end-1], max_scores[wsize-1][j >> SHIFT]);
         }
 
-        for (unsigned int i = 1; i < wsize; ++i){
+        for (size_t i = 1; i < wsize; ++i){
             
             for (unsigned int j = 0; j < rows; ++j){
                 max_scores[wsize-i-1][j >> SHIFT] = std::max(mat[j][end-i-1] + max_scores[wsize-i][j & Q_MASK], max_scores[wsize-i-1][j >> SHIFT]);
@@ -253,7 +259,7 @@ std::pair<bool, double> MotifH::check_hit(const std::string& s, const vector<uns
                 return std::make_pair(false, score);
             }
 
-            CODE = MASK & (CODE << SHIFT) ^ alphabet_map[s[ii + i + q - 1]];
+            CODE = (MASK & (CODE << SHIFT)) ^ alphabet_map[s[ii + i + q - 1]];
             score += mat[CODE][i];
         }
     }


### PR DESCRIPTION
Mostly these are inconsistent usage of int vs. unsigned int vs. long vs.
size_t, plus one abstract base class that needed a virtual destructor
and a few logical expressions for which clang considers parentheses to
be necessary for clarity.

Also fix a couple of issues found by clang-tidy, mostly related to
narrowing integer conversions.  Avoided touching things that might
affect the API or floating point results.